### PR TITLE
Add files via upload

### DIFF
--- a/cardian_bot.lua
+++ b/cardian_bot.lua
@@ -26,7 +26,7 @@
 
 -- _addon.name = 'Cardian_Bot'
 -- _addon.author = 'Stephen Kinnett'
--- _addon.version = '0.0.0.2'
+-- _addon.version = '0.0.0.3'
 
 local discordia = require('discordia')
 local client = discordia.Client()
@@ -254,7 +254,7 @@ function discord_content_found(content)
 		end
 		tmp_user = client:getUser(tmp_user_id)
 		return(tmp_user.username)
-	else
+	elseif content:sub(1, 1) == "#" or content:sub(1, 1) == ":" or content:sub(1, 2) == "a:" then
 		return("<discord content>")
 	end
 end


### PR DESCRIPTION
Previously, the person running the addon's linkshell contributions didn't show up in Discord.  This is because linkshell_in and linkshell_out are handled differently.  They both parse and appear in Discord now.

Previsously, Cardian replaced anything between "<" and ">" with "<Discord Content>".  This was to prevent showing user_id in linkshell which Discord supplies when a user is pinged.  It prevented running any FFXI commands using "<" and ">" from processing (<t>, <bt>, <hpp>, etc).  This is fixed.  It can now differentiate between Discord and FFXI "<" / ">" commands.

Addressed a screenshot issue where the file name was incorrect so no action was taken.